### PR TITLE
Some changes to make monster interactions better

### DIFF
--- a/Mob.swift
+++ b/Mob.swift
@@ -3,9 +3,16 @@ import Foundation
 import UIKit
 
 class Mob : Entity {
+    
+    enum Team : UInt32 {
+        case FRIEND = 0, FOE
+    }
+    
     var inventory = [ItemTypes : [Item]]()
     
     var gold = 0
+    
+    var team = Team.FRIEND
     
     var hp : Int = 0 {
         didSet {
@@ -68,6 +75,10 @@ class AIMob : Mob {
     // If we're targeting something in particular, it's held here
     weak var target : Entity!
     
+    override init(name: String?, description: String?, char: Character?, color: UIColor?, hp: Int) {
+        super.init(name: name, description: description, char: char, color: color, hp: hp)
+        team = .FOE
+    }
     
     func Wander() -> Action? {
         //random walk

--- a/src/Game.swift
+++ b/src/Game.swift
@@ -156,6 +156,7 @@ class Game {
         _SharedInstance = self
         
         self.playerMob = Mob(name: "Adinex", description: "A brave and noble adventurer", char: "@", color: UIColor.whiteColor(),hp:20)
+        self.playerMob.team = Mob.Team.FRIEND
         self.playerMob.sprite.zPosition = CGFloat(Entity.ZOrder.PLAYER.rawValue)
         
         //add test items
@@ -237,13 +238,24 @@ class Game {
         let targetsquare = mob.coords + action.direction
         let targets = level.things.filter({ $0 is Mob && $0.coords == targetsquare }) as! [Mob]
         for target in targets {
-            
-            let attack = mob.DC - target.AC
-            if (attack < 0) {
-                Log("\(mob.name) misses \(target.name)!")
+            if(target.team == mob.team) {
+                Log("\(mob.name) and \(target.name) trade places")
+                let tmp = target.coords
+                target.coords = mob.coords
+                mob.coords = tmp                
             } else {
-                Log("\(mob.name) hits \(target.name) for \(attack)HP!")
-                target.hp -= attack
+                
+                let attack = mob.DC - target.AC
+                
+                //only log if the player was involved
+                if(mob.team == playerMob.team || target.team == playerMob.team) {
+                    if (attack < 0) {
+                        Log("\(mob.name) misses \(target.name)!")
+                    } else {
+                        Log("\(mob.name) hits \(target.name) for \(attack)HP!")
+                        target.hp -= attack
+                    }
+                }
             }
         }
         


### PR DESCRIPTION
- Interactions are based on teams. Monsters are all on the same team
(FOE) and player is on another one (FRIEND). Teammates don't attack
each other, they just trade places. There is room for additional teams
in the future.

- Interactions are only logged if the player's team (player or their
allies) are involved (to avoid 100 'Monster and Monster trade places'
logs)

Fixes #5 